### PR TITLE
電話番号のバリデーション条件の変更

### DIFF
--- a/src/jp.co.froide.exercise.TeamCoffein/src/main/java/jp/co/froide/exercise/TeamCoffein/form/EmployeeForm.java
+++ b/src/jp.co.froide.exercise.TeamCoffein/src/main/java/jp/co/froide/exercise/TeamCoffein/form/EmployeeForm.java
@@ -29,7 +29,7 @@ public class EmployeeForm implements Serializable {
     @NotNull
     Integer dept_id;
 
-    @Pattern(regexp = "^0\\d{10,11}$", message = "半角数字で電話番号を入力してください。")
+    @Pattern(regexp = "^0\\d{9,10}$", message = "半角数字で電話番号を入力してください。")
     String tel;
 
     @Length(min=0, max=255)


### PR DESCRIPTION
{10,11}から{9,10}に変更
先頭の０の後ろの文字数制限であったため